### PR TITLE
xbox: Disable unavailable functions (cinttypes: `wcstoimax` / `wcstoumax`)

### DIFF
--- a/include/cinttypes
+++ b/include/cinttypes
@@ -249,8 +249,10 @@ using::imaxabs;
 using::imaxdiv;
 using::strtoimax;
 using::strtoumax;
+#ifndef NXDK
 using::wcstoimax;
 using::wcstoumax;
+#endif // NXDK
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
Similar to https://github.com/XboxDev/nxdk-libcxx/commit/4caa4847b224fbab4ab6999731f13f4d584ec8b0